### PR TITLE
Log::GetStrEnumConversionMap now returns unordered_map

### DIFF
--- a/src/logging/include/log.hpp
+++ b/src/logging/include/log.hpp
@@ -2,7 +2,6 @@
 #define LOG_HPP
 
 #include <memory>
-#include <map>
 #include <unordered_map>
 
 #include <spdlog/spdlog.h>
@@ -25,7 +24,7 @@ public:
 	/// \brief A getter function for the daemon logger.
 	static std::shared_ptr<spdlog::logger>& GetLogger(Logger logger) { return s_Loggers.at(logger); }
 
-    static std::map<std::string, spdlog::level::level_enum> GetStrEnumConversionMap();
+    static std::unordered_map<std::string, spdlog::level::level_enum> GetStrEnumConversionMap();
 private:
     inline static std::unordered_map<Logger, std::shared_ptr<spdlog::logger>> s_Loggers;
 };

--- a/src/logging/log.cpp
+++ b/src/logging/log.cpp
@@ -3,6 +3,7 @@
 
 #include <spdlog/sinks/stdout_color_sinks.h>
 #include <spdlog/sinks/basic_file_sink.h>
+#include <unordered_map>
 #include <vector>
 
 void Log::Init(spdlog::level::level_enum level) {
@@ -30,7 +31,7 @@ void Log::Init(spdlog::level::level_enum level) {
     }
 }
 
-std::map<std::string, spdlog::level::level_enum> Log::GetStrEnumConversionMap() {
+std::unordered_map<std::string, spdlog::level::level_enum> Log::GetStrEnumConversionMap() {
     return {{"trace", spdlog::level::level_enum::trace},
         {"debug", spdlog::level::level_enum::debug},
         {"info", spdlog::level::level_enum::info},


### PR DESCRIPTION
Log::GetStrEnumConversionMap now returns unordered_map, as opposed to a wap. This makes the code _every so slightly_ faster. But not by much. Seriously, it's probably even imperceptible if you were to run it on an IBM clone.